### PR TITLE
Implement "jmp" - via a hack

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ We don't support anywhere near the complete instruction-set which an assembly la
   * Move a number into the specified register.
 * `nop`
   * Do nothing.
+* `push $NUMBER`, or `push $IDENTIFIER`
+  * See [jmp.asm](jmp.asm) for an example.
+* `ret`
+  * Return from call.
+  * **NOTE**: We don't actually support making calls, though that can be emulated via `push` - see [jmp.asm](jmp.asm) for an example.
 * `xor $REG, $REG`
   * Set the given register to be zero.
 * `int 0x80`
@@ -52,7 +57,8 @@ There is support for storing fixed-data within our program, and locating that.  
 
 We also have some other (obvious) limitations:
 
-* There is notably no support for comparison instructions, stack instructions and control-flow instructions.
+* There is notably no support for comparison instructions, and jumping instructions.
+  * We _emulate_ (unconditional) jump instructions via "`push`" and "`ret`", see [jmp.asm](jmp.asm) for an example of that.
 * The entry-point is __always__ at the beginning of the source.
 * You can only reference data AFTER it has been declared.
   * These are added to the `data` section of the generated binary, but must be defined first.

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -131,6 +131,8 @@ func (p *Parser) parseInstruction() Node {
 	args["int"] = 1
 	args["mov"] = 2
 	args["nop"] = 0
+	args["push"] = 1
+	args["ret"] = 0
 	args["xor"] = 2
 
 	// Get the current instruction

--- a/token/token.go
+++ b/token/token.go
@@ -47,12 +47,14 @@ var known = map[string]Type{
 	"DB": DB,
 
 	// instructions we handle
-	"mov": INSTRUCTION,
-	"xor": INSTRUCTION,
-	"inc": INSTRUCTION,
-	"add": INSTRUCTION,
-	"int": INSTRUCTION,
-	"nop": INSTRUCTION,
+	"add":  INSTRUCTION,
+	"inc":  INSTRUCTION,
+	"int":  INSTRUCTION,
+	"mov":  INSTRUCTION,
+	"nop":  INSTRUCTION,
+	"push": INSTRUCTION,
+	"ret":  INSTRUCTION,
+	"xor":  INSTRUCTION,
 
 	// registers
 	// TODO: more


### PR DESCRIPTION
Implementing a jump is hard, because x86 jumps are relative, kinda.

Instead fake a jump via push/ret combinatoin.

This closes #8.