### PR TITLE
Allow all registers for push/pop

### DIFF
--- a/instructions/instructions.go
+++ b/instructions/instructions.go
@@ -33,6 +33,7 @@ func init() {
 	InstructionLengths["int"] = 1
 	InstructionLengths["mov"] = 2
 	InstructionLengths["nop"] = 0
+	InstructionLengths["pop"] = 1
 	InstructionLengths["push"] = 1
 	InstructionLengths["ret"] = 0
 	InstructionLengths["sub"] = 2


### PR DESCRIPTION
This updates #10, by allowing "all the registers" to work for push/pop