### PR TITLE
Allow indirection

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,19 @@ We don't support anywhere near the complete instruction-set which an assembly la
 * `add $REG, $REG` + `add $REG, $NUMBER`
   * Add a number, or the contents of another register, to a register.
 * `dec $REG`
-  * Decrement the contents of the given register.
+  * Decrement the contents of the specified register.
+  * We also support indirection, so the following work:
+    * `inc byte ptr [$REG]`
+    * `inc word ptr [$REG]`
+    * `inc dword ptr [$REG]`
+    * `inc qword ptr [$REG]`
 * `inc $REG`
-  * Increment the contents of the given register.
+  * Increment the contents of the specified register.
+  * We also support indirection, so the following work:
+    * `inc byte ptr [$REG]`
+    * `inc word ptr [$REG]`
+    * `inc dword ptr [$REG]`
+    * `inc qword ptr [$REG]`
 * `mov $REG, $NUMBER`
 * `mov $REG, $REG`
   * Move a number into the specified register.
@@ -66,12 +76,18 @@ We don't support anywhere near the complete instruction-set which an assembly la
 * Processor (flag) control instructions:
   * `clc`, `cld`, `cli`, `cmc`, `stc`, `std`, and `sti`.
 
-Note that in **all cases** we only support the following set of (four) registers:
+Note that we really only support the following registers, you'll see that we only support the 64-bit registers (which means `rax` is supported but `eax`, `ax`, `ah`, and `al` are specifically __not__ supported):
 
 * `rax`
-* `rbx`
 * `rcx`
 * `rdx`
+* `rbx`
+* `rsp`
+* `rbp`
+* `rsi`
+* `rdi`
+
+There is _some_ support for the extended registers `r8`-`r15`, but this varies on a per-instruction basis and should not be relied upon.
 
 There is support for storing fixed-data within our program, and locating that.  See [hello.asm](hello.asm) for an example of that.
 
@@ -206,7 +222,7 @@ Or show string-contents at an address:
 
 Feel free to report, as this is more a proof of concept rather than a robust tool they are to be expected.
 
-Specifically I expect that we're missing support for many instructions, but I hope the code generated for those that is present is correct.
+Specifically we're missing support for many instructions, but I hope the code generated for those that is present is correct.
 
 
 Steve

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -288,7 +288,7 @@ func (c *Compiler) compileInstruction(i parser.Instruction) error {
 	return fmt.Errorf("unknown instruction %v", i)
 }
 
-// return register number - used for `mov`
+// return register number - used for `dec`, `inc`, and `mov`.
 func (c *Compiler) getreg(reg string) int {
 
 	// registers
@@ -422,28 +422,67 @@ func (c *Compiler) assembleADD(i parser.Instruction) error {
 // accembleDEC handles dec rax, rbx, etc.
 func (c *Compiler) assembleDEC(i parser.Instruction) error {
 
-	table := make(map[string][]byte)
-	table["rax"] = []byte{0x48, 0xff, 0xc8}
-	table["rbx"] = []byte{0x48, 0xff, 0xcb}
-	table["rcx"] = []byte{0x48, 0xff, 0xc9}
-	table["rdx"] = []byte{0x48, 0xff, 0xca}
-	table["rbp"] = []byte{0x48, 0xff, 0xcd}
-	table["rsp"] = []byte{0x48, 0xff, 0xcc}
-	table["rsi"] = []byte{0x48, 0xff, 0xce}
-	table["rdi"] = []byte{0x48, 0xff, 0xcf}
-	table["r8"] = []byte{0x48, 0xff, 0xc8}
-	table["r9"] = []byte{0x48, 0xff, 0xc9}
-	table["r10"] = []byte{0x48, 0xff, 0xca}
-	table["r11"] = []byte{0x48, 0xff, 0xcb}
-	table["r12"] = []byte{0x48, 0xff, 0xcc}
-	table["r13"] = []byte{0x48, 0xff, 0xcd}
-	table["r14"] = []byte{0x48, 0xff, 0xce}
-	table["r15"] = []byte{0x48, 0xff, 0xcf}
+	// Decrement the contents of a register
+	if i.Operands[0].Indirection == false {
+		// prefix
+		c.code = append(c.code, []byte{0x48, 0xff}...)
 
-	// Is this "dec rax|rbx..|rdx", or something in the table?
-	bytes, ok := table[i.Operands[0].Literal]
-	if ok {
-		c.code = append(c.code, bytes...)
+		// register name
+		reg := 0xc0 + c.getreg(i.Operands[0].Literal)
+		c.code = append(c.code, byte(reg))
+
+		return nil
+	}
+
+	// indirect: byte
+	if i.Operands[0].Size == 8 {
+		// prefix
+		c.code = append(c.code, []byte{0x67, 0xfe}...)
+
+		// register name
+		reg := c.getreg(i.Operands[0].Literal)
+		reg += 0x08
+		c.code = append(c.code, byte(reg))
+
+		return nil
+	}
+
+	// indirect: word
+	if i.Operands[0].Size == 16 {
+		// prefix
+		c.code = append(c.code, []byte{0x67, 0x66, 0xff}...)
+
+		// register name
+		reg := c.getreg(i.Operands[0].Literal)
+		reg += 0x08
+		c.code = append(c.code, byte(reg))
+
+		return nil
+	}
+
+	// indirect: double word
+	if i.Operands[0].Size == 32 {
+		// prefix
+		c.code = append(c.code, []byte{0x67, 0xff}...)
+
+		// register name
+		reg := c.getreg(i.Operands[0].Literal)
+		reg += 0x08
+		c.code = append(c.code, byte(reg))
+
+		return nil
+	}
+
+	// indirect: quad word
+	if i.Operands[0].Size == 64 {
+		// prefix
+		c.code = append(c.code, []byte{0x67, 0x48, 0xff}...)
+
+		// register name
+		reg := c.getreg(i.Operands[0].Literal)
+		reg += 0x08
+		c.code = append(c.code, byte(reg))
+
 		return nil
 	}
 
@@ -453,28 +492,63 @@ func (c *Compiler) assembleDEC(i parser.Instruction) error {
 // assembleINC handles inc rax, rbx, etc.
 func (c *Compiler) assembleINC(i parser.Instruction) error {
 
-	table := make(map[string][]byte)
-	table["rax"] = []byte{0x48, 0xff, 0xc0}
-	table["rbx"] = []byte{0x48, 0xff, 0xc3}
-	table["rcx"] = []byte{0x48, 0xff, 0xc1}
-	table["rdx"] = []byte{0x48, 0xff, 0xc2}
-	table["rbp"] = []byte{0x48, 0xff, 0xc5}
-	table["rsp"] = []byte{0x48, 0xff, 0xc4}
-	table["rsi"] = []byte{0x48, 0xff, 0xc6}
-	table["rdi"] = []byte{0x48, 0xff, 0xc7}
-	table["r8"] = []byte{0x48, 0xff, 0xc0}
-	table["r9"] = []byte{0x48, 0xff, 0xc1}
-	table["r10"] = []byte{0x48, 0xff, 0xc2}
-	table["r11"] = []byte{0x48, 0xff, 0xc3}
-	table["r12"] = []byte{0x48, 0xff, 0xc4}
-	table["r13"] = []byte{0x48, 0xff, 0xc5}
-	table["r14"] = []byte{0x48, 0xff, 0xc6}
-	table["r15"] = []byte{0x48, 0xff, 0xc7}
+	// Increment the contents of a register
+	if i.Operands[0].Indirection == false {
+		// prefix
+		c.code = append(c.code, []byte{0x48, 0xff}...)
 
-	// Is this "inc rax|rbx..|rdx", or something in the table?
-	bytes, ok := table[i.Operands[0].Literal]
-	if ok {
-		c.code = append(c.code, bytes...)
+		// register name
+		reg := 0xc0 + c.getreg(i.Operands[0].Literal)
+		c.code = append(c.code, byte(reg))
+
+		return nil
+	}
+
+	// indirect: byte
+	if i.Operands[0].Size == 8 {
+		// prefix
+		c.code = append(c.code, []byte{0x67, 0xfe}...)
+
+		// register name
+		reg := c.getreg(i.Operands[0].Literal)
+		c.code = append(c.code, byte(reg))
+
+		return nil
+	}
+
+	// indirect: word
+	if i.Operands[0].Size == 16 {
+		// prefix
+		c.code = append(c.code, []byte{0x67, 0x66, 0xff}...)
+
+		// register name
+		reg := c.getreg(i.Operands[0].Literal)
+		c.code = append(c.code, byte(reg))
+
+		return nil
+	}
+
+	// indirect: double word
+	if i.Operands[0].Size == 32 {
+		// prefix
+		c.code = append(c.code, []byte{0x67, 0xff}...)
+
+		// register name
+		reg := c.getreg(i.Operands[0].Literal)
+		c.code = append(c.code, byte(reg))
+
+		return nil
+	}
+
+	// indirect: quad word
+	if i.Operands[0].Size == 64 {
+		// prefix
+		c.code = append(c.code, []byte{0x67, 0x48, 0xff}...)
+
+		// register name
+		reg := c.getreg(i.Operands[0].Literal)
+		c.code = append(c.code, byte(reg))
+
 		return nil
 	}
 

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -222,7 +222,7 @@ func (c *Compiler) compileInstruction(i parser.Instruction) error {
 		return nil
 
 	case "int":
-		n, err := c.argToByte(i.Operands[0])
+		n, err := c.argToByte(i.Operands[0].Token)
 		if err != nil {
 			return err
 		}
@@ -392,7 +392,7 @@ func (c *Compiler) assembleADD(i parser.Instruction) error {
 		i.Operands[1].Type == token.NUMBER {
 
 		// Convert the integer to a four-byte/64-bit value
-		n, err := c.argToByteArray(i.Operands[1])
+		n, err := c.argToByteArray(i.Operands[1].Token)
 		if err != nil {
 			return err
 		}
@@ -508,7 +508,7 @@ func (c *Compiler) assembleMov(i parser.Instruction, label bool) error {
 		c.code = append(c.code, byte(reg))
 
 		// value
-		n, err := c.argToByteArray(i.Operands[1])
+		n, err := c.argToByteArray(i.Operands[1].Token)
 		if err != nil {
 			return err
 		}
@@ -585,7 +585,7 @@ func (c *Compiler) assemblePush(i parser.Instruction) error {
 
 	// Is this a number?  Just output it
 	if i.Operands[0].Type == token.NUMBER {
-		n, err := c.argToByteArray(i.Operands[1])
+		n, err := c.argToByteArray(i.Operands[1].Token)
 		if err != nil {
 			return err
 		}
@@ -608,11 +608,11 @@ func (c *Compiler) assemblePush(i parser.Instruction) error {
 	// is this a register?
 	table := make(map[string][]byte)
 	table["rax"] = []byte{0x50}
-	table["rbx"] = []byte{0x53}
 	table["rcx"] = []byte{0x51}
 	table["rdx"] = []byte{0x52}
-	table["rbp"] = []byte{0x55}
+	table["rbx"] = []byte{0x53}
 	table["rsp"] = []byte{0x54}
+	table["rbp"] = []byte{0x55}
 	table["rsi"] = []byte{0x56}
 	table["rdi"] = []byte{0x57}
 	table["r8"] = []byte{0x41, 0x50}
@@ -654,7 +654,7 @@ func (c *Compiler) assembleSUB(i parser.Instruction) error {
 		i.Operands[1].Type == token.NUMBER {
 
 		// Convert the integer to a four-byte/64-bit value
-		n, err := c.argToByteArray(i.Operands[1])
+		n, err := c.argToByteArray(i.Operands[1].Token)
 		if err != nil {
 			return err
 		}

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -84,6 +84,14 @@ func (l *Lexer) NextToken() token.Token {
 	case rune(','):
 		tok = token.Token{Type: token.COMMA, Literal: ","}
 
+	case rune('['):
+		tok = token.Token{Type: token.LSQUARE, Literal: "["}
+
+	case rune(']'):
+
+		l.readChar()
+		return (l.NextToken())
+
 	case rune('"'):
 		str, err := l.readString('"')
 		if err == nil {

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -17,6 +17,33 @@ func TestComment(t *testing.T) {
 	}
 }
 
+func TestData(t *testing.T) {
+
+	input := `.foo
+.`
+
+	tests := []struct {
+		expectedType    token.Type
+		expectedLiteral string
+	}{
+		{token.DATA, "foo"},
+		{token.ILLEGAL, "unterminated label"},
+		{token.EOF, ""},
+	}
+
+	l := New(input)
+	for i, tt := range tests {
+		tok := l.NextToken()
+		if tok.Type != tt.expectedType {
+			t.Fatalf("tests[%d] - tokentype wrong, expected=%q, got=%q", i, tt.expectedType, tok.Type)
+		}
+		if tok.Literal != tt.expectedLiteral {
+			t.Fatalf("tests[%d] - Literal wrong, expected=%q, got=%q", i, tt.expectedLiteral, tok.Literal)
+		}
+	}
+
+}
+
 func TestMov(t *testing.T) {
 
 	input := `
@@ -80,15 +107,15 @@ func TestLabel(t *testing.T) {
 			t.Fatalf("tests[%d] - Literal wrong, expected=%q, got=%q", i, tt.expectedLiteral, tok.Literal)
 		}
 	}
-
 }
 
 func TestString(t *testing.T) {
 
 	input := `
 .foo DB "Steve\r\n\t\"\\"
-.bar DB "Open
-`
+.test DB "steve\
+ kemp"
+.bar DB "Open\`
 
 	tests := []struct {
 		expectedType    token.Type
@@ -98,10 +125,44 @@ func TestString(t *testing.T) {
 		{token.DB, "DB"},
 		{token.STRING, "Steve\r\n\t\"\\"},
 
+		{token.DATA, "test"},
+		{token.DB, "DB"},
+		{token.STRING, "steve kemp"},
+
 		{token.DATA, "bar"},
 		{token.DB, "DB"},
 		{token.ILLEGAL, "unterminated string"},
 
+		{token.EOF, ""},
+	}
+
+	l := New(input)
+	for i, tt := range tests {
+		tok := l.NextToken()
+		if tok.Type != tt.expectedType {
+			t.Fatalf("tests[%d] - tokentype wrong, expected=%q, got=%q", i, tt.expectedType, tok.Type)
+		}
+		if tok.Literal != tt.expectedLiteral {
+			t.Fatalf("tests[%d] - Literal wrong, expected=%q, got=%q", i, tt.expectedLiteral, tok.Literal)
+		}
+	}
+
+}
+
+func TestBrackets(t *testing.T) {
+
+	// Note "[" is emitted as you expect, but "]" is swallowed.
+	input := `mov eax, [eax]`
+
+	tests := []struct {
+		expectedType    token.Type
+		expectedLiteral string
+	}{
+		{token.INSTRUCTION, "mov"},
+		{token.IDENTIFIER, "eax"},
+		{token.COMMA, ","},
+		{token.LSQUARE, "["},
+		{token.IDENTIFIER, "eax"},
 		{token.EOF, ""},
 	}
 

--- a/parser/ast.go
+++ b/parser/ast.go
@@ -43,16 +43,32 @@ func (d Data) String() string {
 	return fmt.Sprintf("<DATA: name:%s data:%v>", d.Name, d.Contents)
 }
 
-// Operand is the operand
+// Operand is used to hold the operand for an instruction.
+//
+// Some instructions have zero operands (e.g. `nop`), others have
+// one (e.g. `inc rax`), and finally we have several which take two
+// operands (e.g. `mov rax, rbx`).
+//
 type Operand struct {
+	// Token contains our parent token.
 	token.Token
 
-	// size is "byte ptr"
-	// size is "word ptr"
-	// size is "qword ptr"
+	// If we're operating upon memory-addresses we need to be
+	// able to understand the size of the thing we're operating
+	// upon.
+	//
+	// For example `inc byte ptr [rax]` will increment a byte,
+	// or 8 bits.  We have different define sizes available to us:
+	//
+	//   byte -> 8 bits.
+	//   word -> 16 bits.
+	//  dword -> 32 bites.
+	//  qword -> 64 bites.
 	Size int
 
-	// Indirection?
+	// Is indirection used?
+	//
+	// i.e. `rax` has no indirection, but `[rax]` does.
 	Indirection bool
 }
 
@@ -68,8 +84,7 @@ type Instruction struct {
 
 	// Operands holds the operands for this instruction.
 	//
-	// This will usually be an integer, a pair of registers,
-	// or a register and an integer
+	// Operands will include numbers, registers, and indrected registers.
 	Operands []Operand
 }
 

--- a/parser/ast.go
+++ b/parser/ast.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"fmt"
+
 	"github.com/skx/assembler/token"
 )
 
@@ -42,6 +43,19 @@ func (d Data) String() string {
 	return fmt.Sprintf("<DATA: name:%s data:%v>", d.Name, d.Contents)
 }
 
+// Operand is the operand
+type Operand struct {
+	token.Token
+
+	// size is "byte ptr"
+	// size is "word ptr"
+	// size is "qword ptr"
+	Size int
+
+	// Indirection?
+	Indirection bool
+}
+
 // Instruction holds a parsed instruction.
 //
 // For example "mov rax, rax".
@@ -56,7 +70,7 @@ type Instruction struct {
 	//
 	// This will usually be an integer, a pair of registers,
 	// or a register and an integer
-	Operands []token.Token
+	Operands []Operand
 }
 
 // String outputs this Error structure as a string

--- a/token/token.go
+++ b/token/token.go
@@ -24,6 +24,8 @@ type Token struct {
 const (
 	// Basic things
 	COMMA       = ","
+	LSQUARE     = "["
+	RSQUARE     = "]"
 	EOF         = "EOF"
 	LABEL       = "LABEL"
 	DATA        = "DATA"


### PR DESCRIPTION
This pull-request updates #16, by allowing instructions to be parsed
which operate upon indirection.

For example:

        mov rax, [rbx]

Or:

        inc byte ptr [rax]
        inc word ptr [rax]
        inc qword ptr [rax]

Those instructions are not yet encoded, but they will be parsed.

We recognize two flags:

* Indirection
  * When an address is involved.
* Size
  * For the size which we're operating upon
    * `byte ptr` -> 8-bits
    * `word ptr` -> 16-bits
    * `dword ptr` -> 32-bits
    * `qword ptr` -> 64-bits

(Of course we still only support the use of 64-bit registers, we
recognize RAX, but not EAX, AX, AH, or AL.)