### PR TITLE
Allow indirection for mov

### DIFF
--- a/call.asm
+++ b/call.asm
@@ -23,6 +23,13 @@
         mov rcx, message
         call print_asciiz_string
 
+        ;; print a string with ZERO size calculation
+        ;;
+        ;; BUT change the " " to "*"
+        mov rdx, message
+        call print_asciiz_string_with_stars
+
+
         ;; print a string with an explicit size
         mov rcx, goodbye
         mov rdx, 15
@@ -45,7 +52,7 @@
 
         ret
 
-        ;; Routing to print a '0x00'-terminated string
+        ;; Routine to print a '0x00'-terminated string
         ;;
         ;; Assumes string address is in RCX
 :print_asciiz_string
@@ -62,6 +69,27 @@
                                 ; rdx has the mesage
         call print_string       ; call the print routine
         ret                     ; and return from here
+
+
+
+        ;; Print a string, terminated by NULL, but change " " to "*"
+        ;;
+        ;; NOTE: This destroys the string in the process.
+:print_asciiz_string_with_stars
+        push rdx
+:star_loop
+        cmp byte ptr [rdx], 0x00   ; end of string? we're done
+        je star_loop_over
+        cmp byte ptr [rdx], 0x20   ; is this a space?
+        jne star_loop_cont         ; if not continue
+        mov byte ptr [rdx], 42     ; so replace with "*"
+:star_loop_cont
+        inc rdx                    ; increase our pointer
+        jmp star_loop              ; loop again
+:star_loop_over
+        pop rcx
+        call print_asciiz_string
+        ret
 
 
         ;; Exit

--- a/elf/elf.go
+++ b/elf/elf.go
@@ -81,7 +81,7 @@ func (e *Elf) buildELF(textSection, dataSection []byte) []byte {
 	// Build Program Header
 	// Text Segment
 	o.WriteBytes(0x01, 0x00, 0x00, 0x00) // PT_LOAD, loadable segment. Both data and text segment use this.
-	o.WriteBytes(0x05, 0x00, 0x00, 0x00) // Flags: 0x4 executable, 0x2 write, 0x1 read
+	o.WriteBytes(0x07, 0x00, 0x00, 0x00) // Flags: 0x4 executable, 0x2 write, 0x1 read
 	o.WriteValue(8, 0)                   // textOffset)          // Offset from the beginning of the file. These values depend on how big the header and segment sizes are.
 	o.WriteValue(8, virtualStartAddress)
 	o.WriteValue(8, virtualStartAddress) // Physical address, irrelavnt on linux.


### PR DESCRIPTION
We've made a bunch of tweaks here, which will close #19 by allowing indirection for some `mov` instructions - not all of them.

We've updated our test-program to allow MODIFYING a string in-place, which required changing the ELF flags in our generated binary, which is a bit gross.

But without more instructions we're limited a little in what we can do.
